### PR TITLE
pa and lectures on  calendars

### DIFF
--- a/_includes/calendar_custom.js
+++ b/_includes/calendar_custom.js
@@ -1,0 +1,1 @@
+/* empty file for users to override */

--- a/_includes/calendar_item.js
+++ b/_includes/calendar_item.js
@@ -1,0 +1,12 @@
+{
+    "type" : "{{type}}",
+    "url" :  "{{ asn.url | relative_url  }}",	   
+    {% if item.num %}"num" : "{{ item.num }}",{% endif %}
+    {% if item.assigned %}"assigned" : "{{ item.assigned }}",{% endif %}
+    {% if item.due %}"due" : "{{ item.due }}",{% endif %}    
+    {% if item.ready %}"ready" : "{{ item.ready }}",{% endif %}
+    {% if item.desc %}"desc" : "{{ item.desc }}",{% endif %}
+    {% if item.exam_date or item.lecture_date or item.date %}
+    "date" : "{{ item.date }}",
+    {% endif %}
+}

--- a/_includes/calendar_item.js
+++ b/_includes/calendar_item.js
@@ -9,6 +9,6 @@
     {% if item.exam_date %}
       "date" : "{{ item.exam_date }}",
     {% elsif item.lecture_date %}
-      "date" : "{{ item.lecture_date }",
+      "date" : "{{ item.lecture_date }}",
     {% endif %}
 }

--- a/_includes/calendar_item.js
+++ b/_includes/calendar_item.js
@@ -1,6 +1,6 @@
 {
     "type" : "{{type}}",
-    "url" :  "{{ asn.url | relative_url  }}",	   
+    "url" :  "{{ item.url | relative_url  }}",	   
     {% if item.num %}"num" : "{{ item.num }}",{% endif %}
     {% if item.assigned %}"assigned" : "{{ item.assigned }}",{% endif %}
     {% if item.due %}"due" : "{{ item.due }}",{% endif %}    

--- a/_includes/calendar_item.js
+++ b/_includes/calendar_item.js
@@ -6,7 +6,9 @@
     {% if item.due %}"due" : "{{ item.due }}",{% endif %}    
     {% if item.ready %}"ready" : "{{ item.ready }}",{% endif %}
     {% if item.desc %}"desc" : "{{ item.desc }}",{% endif %}
-    {% if item.exam_date or item.lecture_date or item.date %}
-    "date" : "{{ item.date }}",
+    {% if item.exam_date %}
+      "date" : "{{ item.exam_date }}",
+    {% elsif item.lecture_date %}
+      "date" : "{{ item.lecture_date }",
     {% endif %}
 }

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -77,7 +77,6 @@ function traverseDates(dates) {
 
 function isHwkOrLabAssignment(hwkOrLab) {
     return hwkOrLab.hasOwnProperty('num') &&
-	hwkOrLab.hasOwnProperty('ready') &&
 	hwkOrLab.hasOwnProperty('desc') &&
  	hwkOrLab.hasOwnProperty('assigned') &&
 	hwkOrLab.hasOwnProperty('due') ;
@@ -86,7 +85,6 @@ function isHwkOrLabAssignment(hwkOrLab) {
 
 function isExam(exam) {
     return exam.hasOwnProperty('num') &&
-	exam.hasOwnProperty('ready') &&
 	exam.hasOwnProperty('desc') &&
  	exam.hasOwnProperty('date');
 }
@@ -235,7 +233,7 @@ function addCalendarTable(cal) {
     
     $('.cal-assignments div[data-asn-type="hwk"]').each(function() {
 	var hwk = ($(this).data("date-value"));
-    if (hwk.ready=="true") {
+    if (hwk.ready && hwk.ready=="true") {
 		$(this).addClass("ready");
 	} else {
 		$(this).addClass("not-ready");
@@ -252,7 +250,7 @@ function addCalendarTable(cal) {
     
     $('.cal-assignments div[data-asn-type="lab"]').each(function() {
 	var asn = $(this).data("date-value");
-    if (asn.ready=="true") {
+	if (asn.ready && asn.ready=="true") {
 		$(this).addClass("ready");
 	} else {
 		$(this).addClass("not-ready");
@@ -268,7 +266,7 @@ function addCalendarTable(cal) {
 
     $('.cal-assignments div[data-asn-type="exam"]').each(function() {
 	var exam = ($(this).data("date-value"));
-    if (exam.ready=="true") {
+    if (exam.ready && exam.ready=="true") {
 		$(this).addClass("ready");
 	} else {
 		$(this).addClass("not-ready");

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -5,49 +5,50 @@ layout: js
 var cal_dates = {{ site.cal_dates}};
 
 var dates = [
-	{% for asn in site.hwk %}
+    {% for c in site.collections %}
+       {% for item in c %}
 	{
-	    "type" : "hwk",
-	    "num" : "{{ asn.num }}",
-	    "ready" :  "{{ asn.ready }}",
-	    "desc" :  "{{ asn.desc }}",
-	    {% if asn.assigned %}
-	    "assigned" :  "{{ asn.assigned }}",
+	    "type" : "{{c.label}}",
+	    "num" : "{{ item.num }}",
+	    "ready" :  "{{ item.ready }}",
+	    "desc" :  "{{ item.desc }}",
+	    {% if item.assigned %}
+	    "assigned" :  "{{ item.assigned }}",
 	    {% endif %}
-	    {% if asn.due %}	    
-	    "due" :  "{{ asn.due }}",
+	    {% if item.due %}	    
+	    "due" :  "{{ item.due }}",
 	    {% endif %}	    	    
-	    "url" :  "{{ asn.url | relative_url  }}",
+	    "url" :  "{{ item.url | relative_url  }}",
 	},
 	{% endfor %}
 	{% for asn in site.lab %}
-	{% if asn.num %}
+	{% if item.num %}
 	{
 	    "type" : "lab",
-	    "num" : "{{ asn.num }}",
-	    "ready" :  "{{ asn.ready }}",
-	    "desc" :  "{{ asn.desc }}",
-	    {% if asn.assigned %}
-	    "assigned" :  "{{ asn.assigned }}",
+	    "num" : "{{ item.num }}",
+	    "ready" :  "{{ item.ready }}",
+	    "desc" :  "{{ item.desc }}",
+	    {% if item.assigned %}
+	    "assigned" :  "{{ item.assigned }}",
 	    {% endif %}
-	    {% if asn.due %}	    
-	    "due" :  "{{ asn.due }}",
+	    {% if item.due %}	    
+	    "due" :  "{{ item.due }}",
 	    {% endif %}	    	    
-	    "url" :  "{{ asn.url | relative_url  }}",
+	    "url" :  "{{ item.url | relative_url  }}",
 	},
 	{% endif %}
 	{% endfor %}
 	{% for asn in site.exam %}
-	{% if asn.add_to_cal == true %}
+	{% if item.add_to_cal == true %}
 	{
 	    "type" : "exam",
-	    "num" : "{{ asn.num }}",
-	    "ready" :  "{{ asn.ready }}",
-	    "desc" :  "{{ asn.desc }}",
-	    {% if asn.exam_date %}
-	    "date" :  "{{ asn.exam_date }}",
+	    "num" : "{{ item.num }}",
+	    "ready" :  "{{ item.ready }}",
+	    "desc" :  "{{ item.desc }}",
+	    {% if item.exam_date %}
+	    "date" :  "{{ item.exam_date }}",
 	    {% endif %}
-	    "url" :  "{{ asn.url | relative_url  }}",
+	    "url" :  "{{ item.url | relative_url  }}",
 	},
 	{% endif %}
 	{% endfor %}

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -189,10 +189,23 @@ function addCalendarTable(cal) {
 	}
 	var link = $('<a />')
 	    .attr('href',hwk.url)
-	    .attr('data-ajax','false')
 	    .text(hwk.num)
 	    .appendTo($(this));
 	$(this).addClass("hwk");
+    });
+
+    $('.cal-assignments div[data-asn-type="pa"]').each(function() {
+	var asn = $(this).data("date-value");
+	if (asn.ready && asn.ready=="true") {
+	    $(this).addClass("ready");
+	} else {
+	    $(this).addClass("not-ready");
+	}
+	var link = $('<a />')
+	    .attr('href',asn.url)
+	    .text(asn.num)
+	    .appendTo($(this));
+	$(this).addClass("pa");
     });
 
     
@@ -206,7 +219,6 @@ function addCalendarTable(cal) {
 	}
 	var link = $('<a />')
 	    .attr('href',asn.url)
-		// .attr('data-ajax','false')
 	    .text(asn.num)
 	    .appendTo($(this));
 	$(this).addClass("lab");
@@ -225,14 +237,29 @@ function addCalendarTable(cal) {
 	    .appendTo($(this));
 	var link = $('<a />')
 	    .attr('href',exam.url)
-	    .attr('data-ajax','false')
 	    .text(exam.num)
 	    .appendTo($(this));
 	$(this).addClass("exam")
 ;
     });
 
-    $('.cal-assignments div[data-asn-type="calDate"]').each(function() {
+
+    $('.cal-assignments div[data-asn-type="lectures"]').each(function() {
+	var asn = $(this).data("date-value");
+	if (asn.ready && asn.ready=="true") {
+	    $(this).addClass("ready");
+	} else {
+	    $(this).addClass("not-ready");
+	}
+	var link = $('<a />')
+	    .attr('href',asn.url)
+	    .text(asn.num)
+	    .prependTo($(this));
+	$(this).addClass("lecture");
+    });
+
+    
+    $('.cal-assignments div[data-asn-type="cal_date"]').each(function() {
 	var cal_date = ($(this).data("date-value"));
 	$(this).addClass("ready");
 

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -5,52 +5,17 @@ layout: js
 var cal_dates = {{ site.cal_dates}};
 
 var dates = [
-	{% for asn in site.hwk %}
-	{
-	    "type" : "hwk",
-	    "num" : "{{ asn.num }}",
-	    "ready" :  "{{ asn.ready }}",
-	    "desc" :  "{{ asn.desc }}",
-	    {% if asn.assigned %}
-	    "assigned" :  "{{ asn.assigned }}",
-	    {% endif %}
-	    {% if asn.due %}	    
-	    "due" :  "{{ asn.due }}",
-	    {% endif %}	    	    
-	    "url" :  "{{ asn.url | relative_url  }}",
-	},
-	{% endfor %}
-	{% for asn in site.lab %}
-	{% if asn.num %}
-	{
-	    "type" : "lab",
-	    "num" : "{{ asn.num }}",
-	    "ready" :  "{{ asn.ready }}",
-	    "desc" :  "{{ asn.desc }}",
-	    {% if asn.assigned %}
-	    "assigned" :  "{{ asn.assigned }}",
-	    {% endif %}
-	    {% if asn.due %}	    
-	    "due" :  "{{ asn.due }}",
-	    {% endif %}	    	    
-	    "url" :  "{{ asn.url | relative_url  }}",
-	},
-	{% endif %}
-	{% endfor %}
-	{% for asn in site.exam %}
-	{% if asn.add_to_cal == true %}
-	{
-	    "type" : "exam",
-	    "num" : "{{ asn.num }}",
-	    "ready" :  "{{ asn.ready }}",
-	    "desc" :  "{{ asn.desc }}",
-	    {% if asn.exam_date %}
-	    "date" :  "{{ asn.exam_date }}",
-	    {% endif %}
-	    "url" :  "{{ asn.url | relative_url  }}",
-	},
-	{% endif %}
-	{% endfor %}
+  {% for c in site.collections %}
+    {% assign type = c.label %}
+    {% for item in site[type] %}
+       {% if item.due or item.assigned or item.exam_date or item.lecture_date or item.date %}
+          {% if item.no_calendar %}
+          {% else %}
+            {% include calendar_item.js %},
+          {% endif %}
+        {% endif %}
+    {% endfor %}
+  {% endfor %}
 ];
 
 for (var i=0; i<cal_dates.length; i++) {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -48,7 +48,7 @@ var dates = {
 	    "ready" :  "{{ asn.ready }}",
 	    "desc" :  "{{ asn.desc }}",
 	    {% if asn.exam_date %}
-	    "exam_date" :  "{{ asn.exam_date }}",
+	    "date" :  "{{ asn.exam_date }}",
 	    {% endif %}
 	    "url" :  "{{ asn.url | relative_url  }}",
 	},
@@ -126,7 +126,7 @@ function isExam(exam) {
     return exam.hasOwnProperty('num') &&
 	exam.hasOwnProperty('ready') &&
 	exam.hasOwnProperty('desc') &&
- 	exam.hasOwnProperty('exam_date');
+ 	exam.hasOwnProperty('date');
 }
 
 function isCalDate(exam) {
@@ -160,7 +160,7 @@ function processExam(item) {
 	reportError("processExam: problem with item" + JSON.stringify(item));
     }
 
-    mmdd_exam_date = moment(item.exam_date).format("MM/DD");
+    mmdd_exam_date = moment(item.date).format("MM/DD");
 
     var assigned = {"asn_type" : "exam", "date_type" : "exam", "value": JSON.stringify(item) };
     pushToDaysOrErrors(assigned,

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -5,17 +5,17 @@ layout: js
 var cal_dates = {{ site.cal_dates}};
 
 var dates = [
-  {% for c in site.collections %}
-    {% assign type = c.label %}
-    {% for item in site[type] %}
-       {% if item.due or item.assigned or item.exam_date or item.lecture_date or item.date %}
-          {% if item.no_calendar %}
-          {% else %}
+  {%- for c in site.collections -%}
+    {%- assign type = c.label -%}
+    {%- for item in site[type] -%}
+       {%- if item.due or item.assigned or item.exam_date or item.lecture_date or item.date -%}
+          {%- if item.no_calendar -%}
+          {%- else -%}
             {% include calendar_item.js %},
-          {% endif %}
-        {% endif %}
-    {% endfor %}
-  {% endfor %}
+          {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+  {%- endfor -%}
 ];
 
 for (var i=0; i<cal_dates.length; i++) {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -61,90 +61,39 @@ function traverseDates(dates) {
 	
     }
     for (var i = 0, len = dates.length; i < len; i++) {
-	if (dates[i].type=="hwk") {
-	    processHwkOrLab(dates[i],"hwk");
-	} else if (dates[i].type=="lab") {
-	    processHwkOrLab(dates[i],"lab"); 
-	} else if (dates[i].type=="exam") {
-	    processExam(dates[i]); 
-	} else if (dates[i].type=="cal_date") {
-	    processCalDate(dates[i]);
-	} else {
-	    console.log("UNKNOWN TYPE: " + dates[i].type);
-	}
+	processItem(dates[i]);
     }
 }
 
-function isHwkOrLabAssignment(hwkOrLab) {
-    return hwkOrLab.hasOwnProperty('num') &&
-	hwkOrLab.hasOwnProperty('desc') &&
- 	hwkOrLab.hasOwnProperty('assigned') &&
-	hwkOrLab.hasOwnProperty('due') ;
-}
+function processItem(item) {
 
-
-function isExam(exam) {
-    return exam.hasOwnProperty('num') &&
-	exam.hasOwnProperty('desc') &&
- 	exam.hasOwnProperty('date');
-}
-
-function isCalDate(exam) {
-    return exam.hasOwnProperty('label') &&
-	exam.hasOwnProperty('date');
-}
-
-
-function processHwkOrLab(item,which) {
-    if (which!="hwk" && which!="lab") {
-	reportError("processHwkorLab: second param must be hwk or lab: " + which);
-	return;
+    if (item.assigned) {
+	mmdd_assigned = moment(item.assigned).format("MM/DD");
+	var assigned = {"asn_type" : item.type,
+			"date_type" : "assigned",
+			"value": JSON.stringify(item) };
+	pushToDaysOrErrors(assigned,mmdd_assigned,cal.days,cal.days_outside_calendar);
     }
-    if (!isHwkOrLabAssignment(item)) {
-	reportError("processHwkOrLab: problem with item" + JSON.stringify(item));
-    }
-
-    mmdd_assigned = moment(item.assigned).format("MM/DD");
-    mmdd_due = moment(item.due).format("MM/DD");
-
-    var assigned = {"asn_type" : which, "date_type" : "assigned", "value": JSON.stringify(item) };
-    pushToDaysOrErrors(assigned,mmdd_assigned,cal.days,cal.days_outside_calendar);
-
-    var due = {"asn_type" : which, "date_type" : "due", "value": JSON.stringify(item)};
-    pushToDaysOrErrors(due,mmdd_due,cal.days,cal.days_outside_calendar);
     
-}
-
-function processExam(item) {
-    if (!isExam(item)) {
-	reportError("processExam: problem with item" + JSON.stringify(item));
+    if (item.due) {
+	var due = {"asn_type" : item.type,
+		   "date_type" : "due",
+		   "value": JSON.stringify(item)};
+	mmdd_due = moment(item.due).format("MM/DD");
+	pushToDaysOrErrors(due,mmdd_due,cal.days,cal.days_outside_calendar);
     }
-
-    mmdd_exam_date = moment(item.date).format("MM/DD");
-
-    var assigned = {"asn_type" : "exam", "date_type" : "exam", "value": JSON.stringify(item) };
-    pushToDaysOrErrors(assigned,
-		       mmdd_exam_date,
-		       cal.days,
-		       cal.days_outside_calendar);
-}
-
-function processCalDate(item) {
-    console.log("processCalDate: item=" + JSON.stringify(item));
     
-    if (!isCalDate(item)) {
-	reportError("processCalDate: problem with item" + JSON.stringify(item));
+    if (item.date) {
+	mmdd_date = moment(item.date).format("MM/DD");
+	var assigned = {"asn_type" : item.type,
+			"date_type" : "date",
+			"value": JSON.stringify(item) };
+	pushToDaysOrErrors(assigned,
+			   mmdd_exam_date,
+			   cal.days,
+			   cal.days_outside_calendar);	
     }
-
-    mmdd_date = moment(item.date).format("MM/DD");
-
-    var calDate = {"asn_type" : "calDate", "date_type" : "label", "value": JSON.stringify(item) };
-    pushToDaysOrErrors(calDate,
-		       mmdd_date,
-		       cal.days,
-		       cal.days_outside_calendar);
 }
-
 
 // Used to cal.days[date], but fail over to
 //  the cal.days_outside_calendar as a backup

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -89,7 +89,7 @@ function processItem(item) {
 			"date_type" : "date",
 			"value": JSON.stringify(item) };
 	pushToDaysOrErrors(assigned,
-			   mmdd_exam_date,
+			   mmdd_date,
 			   cal.days,
 			   cal.days_outside_calendar);	
     }

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -5,11 +5,16 @@ var dates = {
     "hwk": [
 	{% for asn in site.hwk %}
 	{
+	    "type" : "hwk",
 	    "num" : "{{ asn.num }}",
 	    "ready" :  "{{ asn.ready }}",
 	    "desc" :  "{{ asn.desc }}",
+	    {% if asn.assigned %}
 	    "assigned" :  "{{ asn.assigned }}",
+	    {% endif %}
+	    {% if asn.due %}	    
 	    "due" :  "{{ asn.due }}",
+	    {% endif %}	    	    
 	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endfor %}
@@ -18,11 +23,16 @@ var dates = {
 	{% for asn in site.lab %}
 	{% if asn.num %}
 	{
+	    "type" : "lab",
 	    "num" : "{{ asn.num }}",
 	    "ready" :  "{{ asn.ready }}",
 	    "desc" :  "{{ asn.desc }}",
+	    {% if asn.assigned %}
 	    "assigned" :  "{{ asn.assigned }}",
+	    {% endif %}
+	    {% if asn.due %}	    
 	    "due" :  "{{ asn.due }}",
+	    {% endif %}	    	    
 	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endif %}
@@ -31,12 +41,15 @@ var dates = {
 
     "exam": [
 	{% for asn in site.exam %}
-	 {% if asn.layout == "exam_info" %}
+	{% if asn.add_to_cal == true %}
 	{
+	    "type" : "exam",
 	    "num" : "{{ asn.num }}",
 	    "ready" :  "{{ asn.ready }}",
 	    "desc" :  "{{ asn.desc }}",
+	    {% if asn.exam_date %}
 	    "exam_date" :  "{{ asn.exam_date }}",
+	    {% endif %}
 	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endif %}

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -5,50 +5,49 @@ layout: js
 var cal_dates = {{ site.cal_dates}};
 
 var dates = [
-    {% for c in site.collections %}
-       {% for item in c %}
+	{% for asn in site.hwk %}
 	{
-	    "type" : "{{c.label}}",
-	    "num" : "{{ item.num }}",
-	    "ready" :  "{{ item.ready }}",
-	    "desc" :  "{{ item.desc }}",
-	    {% if item.assigned %}
-	    "assigned" :  "{{ item.assigned }}",
+	    "type" : "hwk",
+	    "num" : "{{ asn.num }}",
+	    "ready" :  "{{ asn.ready }}",
+	    "desc" :  "{{ asn.desc }}",
+	    {% if asn.assigned %}
+	    "assigned" :  "{{ asn.assigned }}",
 	    {% endif %}
-	    {% if item.due %}	    
-	    "due" :  "{{ item.due }}",
+	    {% if asn.due %}	    
+	    "due" :  "{{ asn.due }}",
 	    {% endif %}	    	    
-	    "url" :  "{{ item.url | relative_url  }}",
+	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endfor %}
 	{% for asn in site.lab %}
-	{% if item.num %}
+	{% if asn.num %}
 	{
 	    "type" : "lab",
-	    "num" : "{{ item.num }}",
-	    "ready" :  "{{ item.ready }}",
-	    "desc" :  "{{ item.desc }}",
-	    {% if item.assigned %}
-	    "assigned" :  "{{ item.assigned }}",
+	    "num" : "{{ asn.num }}",
+	    "ready" :  "{{ asn.ready }}",
+	    "desc" :  "{{ asn.desc }}",
+	    {% if asn.assigned %}
+	    "assigned" :  "{{ asn.assigned }}",
 	    {% endif %}
-	    {% if item.due %}	    
-	    "due" :  "{{ item.due }}",
+	    {% if asn.due %}	    
+	    "due" :  "{{ asn.due }}",
 	    {% endif %}	    	    
-	    "url" :  "{{ item.url | relative_url  }}",
+	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endif %}
 	{% endfor %}
 	{% for asn in site.exam %}
-	{% if item.add_to_cal == true %}
+	{% if asn.add_to_cal == true %}
 	{
 	    "type" : "exam",
-	    "num" : "{{ item.num }}",
-	    "ready" :  "{{ item.ready }}",
-	    "desc" :  "{{ item.desc }}",
-	    {% if item.exam_date %}
-	    "date" :  "{{ item.exam_date }}",
+	    "num" : "{{ asn.num }}",
+	    "ready" :  "{{ asn.ready }}",
+	    "desc" :  "{{ asn.desc }}",
+	    {% if asn.exam_date %}
+	    "date" :  "{{ asn.exam_date }}",
 	    {% endif %}
-	    "url" :  "{{ item.url | relative_url  }}",
+	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endif %}
 	{% endfor %}

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -93,7 +93,7 @@ function traverseDates(dates) {
 	
     }
     for (var i = 0, len = dates.length; i < len; i++) {
-	if (dates[i].type="hwk") {
+	if (dates[i].type=="hwk") {
 	    processHwkOrLab(dates[i],"hwk");
 	} else if (dates[i].type=="lab") {
 	    processHwkOrLab(dates[i],"lab"); 

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -296,3 +296,7 @@ $(document).ready(function() {
     setUpCalendar();
 });
 
+// Next, we include calendar_custom.js
+// to allow customization of the calendar
+
+{% include calendar_custom.js %}

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -1,8 +1,10 @@
 ---
 layout: js
 ---
-var dates = {
-    "hwk": [
+
+var cal_dates = {{ site.cal_dates}};
+
+var dates = [
 	{% for asn in site.hwk %}
 	{
 	    "type" : "hwk",
@@ -18,8 +20,6 @@ var dates = {
 	    "url" :  "{{ asn.url | relative_url  }}",
 	},
 	{% endfor %}
-    ],
-    "lab": [
 	{% for asn in site.lab %}
 	{% if asn.num %}
 	{
@@ -37,9 +37,6 @@ var dates = {
 	},
 	{% endif %}
 	{% endfor %}
-    ],
-
-    "exam": [
 	{% for asn in site.exam %}
 	{% if asn.add_to_cal == true %}
 	{
@@ -54,11 +51,12 @@ var dates = {
 	},
 	{% endif %}
 	{% endfor %}
-    ],
-    "cal_dates" : {{ site.cal_dates}}
-};
+];
 
-
+for (var i=0; i<cal_dates.length; i++) {
+    cal_dates[i].type = "cal_date";
+}
+dates = dates.concat(cal_dates);
 
 var cal = {
     numWeeks : {{ site.num_weeks }},
@@ -94,24 +92,20 @@ function traverseDates(dates) {
 	}
 	
     }
-    for (var i = 0, len = dates.hwk.length; i < len; i++) {
-	processHwkOrLab(dates.hwk[i],"hwk");
+    for (var i = 0, len = dates.length; i < len; i++) {
+	if (dates[i].type="hwk") {
+	    processHwkOrLab(dates[i],"hwk");
+	} else if (dates[i].type=="lab") {
+	    processHwkOrLab(dates[i],"lab"); 
+	} else if (dates[i].type=="exam") {
+	    processExam(dates[i]); 
+	} else if (dates[i].type=="cal_date") {
+	    processCalDate(dates[i]);
+	} else {
+	    console.log("UNKNOWN TYPE: " + dates[i].type);
+	}
     }
-    for (var i = 0, len = dates.lab.length; i < len; i++) {
-	processHwkOrLab(dates.lab[i],"lab");
-    }
-    for (var i = 0, len = dates.exam.length; i < len; i++) {
-	processExam(dates.exam[i]);
-    }
-    console.log("processCalDate loop:");
-    for (var i = 0, len = dates.cal_dates.length; i < len; i++) {
-	console.log("processCalDate loop, i=" + i);
-	processCalDate(dates.cal_dates[i]);
-    }
-
 }
-
-
 
 function isHwkOrLabAssignment(hwkOrLab) {
     return hwkOrLab.hasOwnProperty('num') &&

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -8,7 +8,10 @@ var dates = [
   {%- for c in site.collections -%}
     {%- assign type = c.label -%}
     {%- for item in site[type] -%}
-       {%- if item.due or item.assigned or item.exam_date or item.lecture_date or item.date -%}
+    {%- if item.due
+     or item.assigned
+     or item.exam_date
+     or item.lecture_date -%}
           {%- if item.no_calendar -%}
           {%- else -%}
             {% include calendar_item.js %},
@@ -132,7 +135,7 @@ function processCalDate(item) {
     console.log("processCalDate: item=" + JSON.stringify(item));
     
     if (!isCalDate(item)) {
-	reportError("processExam: problem with item" + JSON.stringify(item));
+	reportError("processCalDate: problem with item" + JSON.stringify(item));
     }
 
     mmdd_date = moment(item.date).format("MM/DD");

--- a/assets/js/scrape.js
+++ b/assets/js/scrape.js
@@ -10,7 +10,7 @@ var DEBUGGING_ONLY = {
 	{
 	    "label" : "{{name}}",
 	    "items" : [
-		{% for item in site.[name] %}
+		{% for item in site[name] %}
 		{
 		   "collection" : "{{name}}",
 		   "url" : "{{item.url}}",

--- a/assets/js/scrape.js
+++ b/assets/js/scrape.js
@@ -6,8 +6,18 @@ var DEBUGGING_ONLY = {
     "collections" : [
 
 	{% for c in site.collections %}
+	{% assign name = collection.label %}
 	{
-	    "label" : "{{c.label}}"
+	    "label" : "{{name}}",
+	    "items" : [
+		{% for item in site.[name] %}
+		{
+		   "collection" : "{{name}}",
+		   "url" : "{{item.url}}",
+		   "num" : "{{item.num}}",
+		},
+	    {% endfor %}
+	    ]
 	},
 	{% endfor %}
     ],

--- a/assets/js/scrape.js
+++ b/assets/js/scrape.js
@@ -6,17 +6,17 @@ var DEBUGGING_ONLY = {
     "collections" : [
 
 	{% for c in site.collections %}
-	{% assign name = collection.label %}
+	{% assign name = c.label %}
 	{
-	    "label" : "{{name}}",
+	    "label" : "{{ name }}",
 	    "items" : [
 		{% for item in site[name] %}
 		{
-		   "collection" : "{{name}}",
-		   "url" : "{{item.url}}",
-		   "num" : "{{item.num}}",
+		   "collection" : "{{ name }}",
+		   "url" : "{{ item.url }}",
+		   "num" : "{{ item.num }}",
 		},
-	    {% endfor %}
+	        {% endfor %}
 	    ]
 	},
 	{% endfor %}


### PR DESCRIPTION
Dear All:

I had a request from Diba  put a few extra items on the calendar (pa's and lectures).  Turns out I wanted that too, so I've just done complete refactor of the calendar code to make this possible.  It also took some really ugly code and made it more maintainable and easy to understand.

As you do a push to your repos, you'll pick up the necessary changes to the theme.
If all goes as it should this change should be invisible to you, unless you have a pa or "lectures" collection--in which case those items should start appearing on the calendar.

Please keep an eye on the calendar, and let me know if you spot anything that causes concern (e.g. bugs).

Summary of the changes appears below.  This will roll out in a few minutes.

Regards,
Phill 

Changes in this version:

Previously, the only dates to appear on the calendar were:
   hwk, lab, exams, and cal_dates defined in the _config.yml

Now:
* Any item that has an "assigned", "due", "exam_date" or "lecture_date" data item 
  in the front matter *can* be put on the calendar.

* By default, only items from these collections *actually* get put on the calendar 
    hwk, lab, exams, pa, lectures  and the cal_dates in the _config.yml

* Instructors can override this at the course level with some custom code in  a file
   called _include/calendar_custom.js to add items from arbitrary collections to the 
   calendar.   If you have an actual need for that, let me know.

* It is also possible to put custom styles on different types of calendar items, so if you 
   want different kinds of things to appear with different colors, or borders, or whatever,
   that's possible as well.