### PR TITLE
Factor out hwk_header_table from hwk layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ucsb-cs-course-repos/course-repo-jekyll-theme
 
-* Version: 1.1.0 (see: [semver](https://semver.org/) for explanation and [VERSION.md](VERSION.md) for version history)
+* Version: 1.2.0 (see: [semver](https://semver.org/) for explanation and [VERSION.md](VERSION.md) for version history)
 
 
-This is a Jekyll Theme for hosting websites for courses. 
+This is a Jekyll Theme for hosting websites for courses.
 * Compatible with Github Pages
 * Course content can be authored in Markdown or HTML, or a mix
 * Supports:
@@ -20,7 +20,7 @@ This is a Jekyll Theme for hosting websites for courses.
    * Bootstrap
    * JQuery
    * Font-Awesome
-   * Liquid Syntax 
+   * Liquid Syntax
    * Rouge for syntax highlighting
 
 
@@ -38,5 +38,5 @@ If they are desired, they can be added back in a future release:
 TODO
 ----
 
-* In `lecture_next_prev_links.html`, there is a loop that's probably O(n^2).  Try replacing with JS code that will run in time O(n).   
+* In `lecture_next_prev_links.html`, there is a loop that's probably O(n^2).  Try replacing with JS code that will run in time O(n).
 * Can `head.html` and `head_hwk.html` be refactored into a single file with some variables to switch on or off the extra css and js for homework assignments?

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,3 +2,6 @@
 
 * Version: 1.1.0 (see: [semver](https://semver.org/) for explanation and [VERSION.md](VERSION.md) for version history)
    * Added `_includes/hwk_policy_header.html` so that instructors can customize their homework submission policies.
+
+* Version: 1.2.0
+  * Added `_includes/hwk_header_table.html` so that instructors can customize the default homework header table.

--- a/_includes/hwk_header_table.html
+++ b/_includes/hwk_header_table.html
@@ -1,0 +1,15 @@
+<table class="hwk-header-table">
+
+  <tr><th colspan="5" class="hwk-header-name">Name:</th></tr>
+  <tr><th colspan="5" class="hwk-header-subtext">(as it would appear on official course roster)</th></tr>
+  <tr>
+    <th class="hwk-header-umail-label">  Umail address:</th>
+    <th class="hwk-header-umail-entry"> @umail.ucsb.edu</th>
+    <th rowspan="3" class="hwk-header-section"> section<br>{{site.sections}}</th>
+  </tr>
+  <tr>
+    <th colspan="2" style="text-align:left; vertical-align:middle; font-size: 8pt !important; font-family:Arial Narrow, sans-serif; line-height:105%;"> Optional: name you wish to be called<br />if different from name above.
+  </th></tr>
+  <tr>
+    <th colspan="2" style="text-align:left; vertical-align:middle; font-size: 8pt !important; font-family:Arial Narrow, sans-serif; line-height: 105%;"> Optional: name of "homework buddy"<br />(leaving this blank signifies "I worked alone"
+</th></tr></table>

--- a/_includes/lecture_next_prev_links.html
+++ b/_includes/lecture_next_prev_links.html
@@ -13,7 +13,7 @@
   {% endif %}
 {% endfor %}
 
-<table ... style='border: 1px solid #900'>
+<table ... style='border: 1px solid black'>
 <tr>
 {% if prev_link %}
   <td><a href="{{prev_link | relative_url}}">Previous Lecture</a></td>

--- a/_includes/lecture_next_prev_links.html
+++ b/_includes/lecture_next_prev_links.html
@@ -3,7 +3,7 @@
 
 {% for lect in site.lectures %}
   {% if lect.num == page.num %}
-     {% assign get_prev_link = false %}	
+     {% assign get_prev_link = false %}
      {% assign get_next_link = true %}
   {% elsif get_next_link == true %}
      {% assign get_next_link = false %}
@@ -13,7 +13,7 @@
   {% endif %}
 {% endfor %}
 
-<table>
+<table ... style='border: 1px solid #900'>
 <tr>
 {% if prev_link %}
   <td><a href="{{prev_link | relative_url}}">Previous Lecture</a></td>
@@ -24,4 +24,3 @@
 {% endif %}
 </tr>
 </table>
-

--- a/_layouts/hwk.html
+++ b/_layouts/hwk.html
@@ -2,7 +2,7 @@
 <html lang="{{ site.locale | slice: 0,2 | default: "en" }}">
   <head>
     {% include head_hwk.html %}
-    {% include head/custom.html %}    
+    {% include head/custom.html %}
     <title>{{ page.num }} - {{ page.desc }} - {{course}}</title>
   </head>
   <body id="page-top">
@@ -11,7 +11,7 @@
       {% if page.ready %}
       {% else %}
       {% include not_ready_warning.html %}
-      {% endif %}     
+      {% endif %}
       <div id="content"  class="ui-content">
         <div class="hwk-header">
           <div class="hwk-page-header hwk-page-header-template">
@@ -21,22 +21,9 @@
 	      <tr><td class="course-qtr">{{site.course}}&#160;{{site.qtr}}</td>  </tr>
 	    </table>
 	  </div>
-	  
-	  <table class="hwk-header-table">
 
-	    <tr><th colspan="5" class="hwk-header-name">Name:</th></tr>
-	    <tr><th colspan="5" class="hwk-header-subtext">(as it would appear on official course roster)</th></tr>
-	    <tr>
-	      <th class="hwk-header-umail-label">  Umail address:</th>
-	      <th class="hwk-header-umail-entry"> @umail.ucsb.edu</th>
-	      <th rowspan="3" class="hwk-header-section"> section<br>{{site.sections}}</th>
-	    </tr>
-	    <tr>
-	      <th colspan="2" style="text-align:left; vertical-align:middle; font-size: 8pt !important; font-family:Arial Narrow, sans-serif; line-height:105%;"> Optional: name you wish to be called<br />if different from name above.
-	    </th></tr>
-	    <tr>
-	      <th colspan="2" style="text-align:left; vertical-align:middle; font-size: 8pt !important; font-family:Arial Narrow, sans-serif; line-height: 105%;"> Optional: name of "homework buddy"<br />(leaving this blank signifies "I worked alone"
-	  </th></tr></table>
+
+    {%include hwk_header_table.html %}
 
 
 <h1>{{page.num}}: {{ page.desc }}</h1>
@@ -50,16 +37,16 @@
 	    </tr>
 	    <tr class={% if page.ready %}"ready"{% else %}"not-ready"{% endif %}>
 	      <td class="asn_ready">{{page.ready}}</td>
-	      <td class="asn_date" >{{page.assigned | date: "%a %m/%d %I:%M%p"  }}</td> 
+	      <td class="asn_date" >{{page.assigned | date: "%a %m/%d %I:%M%p"  }}</td>
 	      <td class="asn_date" >{{page.due | date: "%a %m/%d %I:%M%p" }}</td>
 	      <td class="pointCount"></td>
 	    </tr>
 	   </table>
 
-{% include hwk_policy_header.html %}	  
+{% include hwk_policy_header.html %}
 
-          
-        </div><!-- hwk-header -->  
+
+        </div><!-- hwk-header -->
           {{ content }}
         </div><!-- content -->
           {% include footer/custom.html %}


### PR DESCRIPTION
Factored out hwk header table in order to be customizable by individual professors (who need to copy hwk_header_table.html into their own _includes directly and make changes there).